### PR TITLE
Fix catalog cart interaction to use addToCart module

### DIFF
--- a/src/js/modules/catalog/catalog.js
+++ b/src/js/modules/catalog/catalog.js
@@ -1,6 +1,7 @@
 import { games } from '../../data/games.js';
 import { FilterManager } from './filter/filter.js';
 import { PaginationManager } from './pagination/pagination.js';
+import { addToCart } from '../homepage/Cart/CartUI.js';
 
 export class GameCatalog {
     constructor(containerSelector, options = {}) {
@@ -198,10 +199,10 @@ export class GameCatalog {
         const game = this.filteredGames.find(g => g.id === gameId);
         if (game) {
             console.log('Adding to cart:', game.name);
-            if (window.addToCart) {
-                window.addToCart(game);
-            } else {
-                console.error('addToCart function not found');
+            try {
+                addToCart(game);
+            } catch (error) {
+                console.error('Failed to add game to cart:', error);
             }
         }
     }


### PR DESCRIPTION
## Summary
- import addToCart directly into GameCatalog
- safely call addToCart without relying on global window reference

## Testing
- `node --check src/js/modules/catalog/catalog.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68961e3f1a98832b88699ecae50a5d81