### PR TITLE
Respect sort direction for rating and default comparators

### DIFF
--- a/src/js/modules/catalog/filter/filter.js
+++ b/src/js/modules/catalog/filter/filter.js
@@ -404,10 +404,10 @@ export class FilterManager {
                 return (a, b) => {
                     const ratingA = a.rating || 0;
                     const ratingB = b.rating || 0;
-                    return (ratingB - ratingA) * directionModifier;
+                    return (ratingA - ratingB) * directionModifier;
                 };
             default:
-                return (a, b) => a.name.localeCompare(b.name);
+                return (a, b) => a.name.localeCompare(b.name) * directionModifier;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure rating comparator respects chosen sort direction
- Apply direction modifier in default sorting fallback